### PR TITLE
feat(Statistic): Get cases/deaths from current region and worldwide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 node_modules/**/*
 .expo/*
 npm-debug.*

--- a/helpers/fetchStatistic.js
+++ b/helpers/fetchStatistic.js
@@ -1,0 +1,46 @@
+import * as Location from "expo-location";
+import axios from "axios";
+
+/**
+ * Get statistic for world and region
+ *
+ * @param currentLocation
+ * @returns {Promise<{}>}
+ */
+const fetchStatistic = async (currentLocation) => {
+  let result = {};
+  
+  let geocode = await Location.reverseGeocodeAsync({
+    latitude: currentLocation.latitude,
+    longitude: currentLocation.longitude
+  });
+  
+  // Get data for region
+  if (geocode && geocode.length > 0) {
+    const { data } = await axios.get('https://rki-covid-api.now.sh/api/states');
+    if (data.states && data.states.length > 0) {
+      const region = data.states.find((item) => item.name === geocode[0].region)
+      result.region = {
+        region: geocode[0].region + ', ' + geocode[0].isoCountryCode,
+        cases: region.count,
+        recovered: 0,
+        deaths: region.deaths
+      }
+    }
+  }
+  
+  // Get data for world
+  const { data } = await axios.get('https://corona.lmao.ninja/all');
+  if (data) {
+    result.world = {
+      cases: data.cases,
+      recovered: data.recovered,
+      deaths: data.deaths,
+      updated: data.updated
+    }
+  }
+  
+  return result
+};
+
+export default fetchStatistic;

--- a/helpers/fetchStatistic.js
+++ b/helpers/fetchStatistic.js
@@ -1,6 +1,24 @@
 import * as Location from "expo-location";
 import axios from "axios";
 
+const rkiRegions = {
+  'Baden-Württemberg': 'BW',
+  'Bayern': 'BY',
+  'Berlin': 'BE',
+  'Brandenburg': 'BB',
+  'Bremen': 'HB',
+  'Hamburg': 'HH',
+  'Mecklenburg-Vorpommern': 'MV',
+  'Niedersachsen': 'NI',
+  'Nordrhein-Westfalen': 'NW',
+  'Rheinland-Pfalz': 'RP',
+  'Saarland': 'SL',
+  'Sachsen': 'SN',
+  'Sachsen-Anhalt': 'ST',
+  'Schleswig-Holstein': 'SH',
+  'Thüringen': 'TH',
+};
+
 /**
  * Get statistic for world and region
  *
@@ -9,38 +27,108 @@ import axios from "axios";
  */
 const fetchStatistic = async (currentLocation) => {
   let result = {};
+  const promises = [];
   
   let geocode = await Location.reverseGeocodeAsync({
     latitude: currentLocation.latitude,
     longitude: currentLocation.longitude
   });
   
-  // Get data for region
+  promises.push(fetchWorld());
+  
+  // Get data for country and region
   if (geocode && geocode.length > 0) {
-    const { data } = await axios.get('https://rki-covid-api.now.sh/api/states');
-    if (data.states && data.states.length > 0) {
-      const region = data.states.find((item) => item.name === geocode[0].region)
-      result.region = {
-        region: geocode[0].region + ', ' + geocode[0].isoCountryCode,
-        cases: region.count,
-        recovered: 0,
-        deaths: region.deaths
+    const geolocation = geocode[0];
+    // Fetch country
+    promises.push(fetchCountry(geolocation.isoCountryCode));
+    if (geolocation.isoCountryCode === 'DE') {
+      // Fetch region
+      promises.push(fetchRegion(rkiRegions[geolocation.region]));
+    }
+  }
+  
+  const response = await Promise.all(promises);
+  result.world = response[0];
+  result.country = response[1];
+  result.region = response[2];
+  
+  return result;
+};
+
+/**
+ * Fetch data from region in country (only for Germany)
+ *
+ * @param region
+ *
+ * @returns {Promise<{}|{recovered: null, cases: *, updated: null, deaths: *}>}
+ */
+const fetchRegion = async (region) => {
+  try {
+    const response = await axios.get('https://rki-covid-api.now.sh/api/states');
+    if (response.status === 200) {
+      // Filter region
+      const data = response.data.states.find((item) => item.code === region);
+      return {
+        region: region,
+        cases: data.count,
+        recovered: null,
+        deaths: data.deaths,
+        updated: null
       }
     }
+  } catch (e) {
+    console.error(e.message);
   }
-  
-  // Get data for world
-  const { data } = await axios.get('https://corona.lmao.ninja/all');
-  if (data) {
-    result.world = {
-      cases: data.cases,
-      recovered: data.recovered,
-      deaths: data.deaths,
-      updated: data.updated
+  return {}
+};
+
+/**
+ * Fetch data from country
+ *
+ * @param country In iso2
+ *
+ * @returns {Promise<{recovered: (number|null), cases: any, updated: null, deaths: any}|{}>}
+ */
+const fetchCountry = async (country) => {
+  try {
+    const response = await axios.get('https://corona-stats.online/' + country + '?format=json');
+    if (response.status === 200) {
+      const data = response.data.data[0];
+      return {
+        country: country,
+        cases: data.cases,
+        recovered: data.recovered,
+        deaths: data.deaths,
+        updated: data.updated
+      }
     }
+  } catch (e) {
+    console.error(e.message);
   }
-  
-  return result
+  return {}
+};
+
+/**
+ * Fetch data from world
+ *
+ * @returns {Promise<{recovered: (number|null), cases: any, updated: null, deaths: any}|{}>}
+ */
+const fetchWorld = async () => {
+  try {
+    const response = await axios.get('https://corona.lmao.ninja/all');
+    if (response.status === 200) {
+      const data = response.data;
+      return {
+        cases: data.cases,
+        recovered: data.recovered,
+        deaths: data.deaths,
+        updated: data.updated
+      }
+    }
+  } catch (e) {
+    console.error(e.message);
+  }
+  return {}
 };
 
 export default fetchStatistic;


### PR DESCRIPTION
I have searched long to find suitable APIs. For Germany (region) and worldwide it works.
Unfortunately there are no numbers for Recovered in Germany.
I would extend the function if I find a better API.